### PR TITLE
Fixed null ref exception in Adobe Atom feed

### DIFF
--- a/FeedReader.Tests/FeedReader.Tests.csproj
+++ b/FeedReader.Tests/FeedReader.Tests.csproj
@@ -60,6 +60,9 @@
     <Compile Include="FullParseTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Feeds\AtomAdobe.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Feeds\AtomBattleNet.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/FeedReader.Tests/Feeds/AtomAdobe.xml
+++ b/FeedReader.Tests/Feeds/AtomAdobe.xml
@@ -1,0 +1,603 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Adobe Blog</title>
+  <link href="https://blog.adobe.com/"/>
+  <id>https://blog.adobe.com/</id>
+    <updated>2021-07-19T00:00:00.000Z</updated>
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/19/adobe-sky-kick-it-out-take-stand-launch-edit.html</id>
+    <title>Adobe, Sky and Kick it Out #Takeastand with the launch of The Edit</title>
+    <updated>2021-07-19T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-adobeskykickitouttakestandlaunchedit embed-internal-19">
+<div>
+<h1 id="adobe-sky-and-kick-it-out-takeastand-with-the-launch-of-the-edit">Adobe, Sky and Kick it Out #Takeastand with the launch of The Edit</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_184a52fe93502901a5e0e4557e8b2b2a3e26946b5.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_184a52fe93502901a5e0e4557e8b2b2a3e26946b5.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="school children recording eachother" loading="eager"></picture>
+</div>
+<div>
+<p>by Adobe Communications</p>
+<p>posted on 07-19-2021</p>
+</div>
+<div>
+<p>Living in a digital-first world means it’s ever more critical for young people, no matter their future job role or sector, to develop creative and digital skills to communicate, collaborate and create effectively in their future workplace.</p>
+<p>However, with the digital divide more concerning than ever before (as reported by the <a href="https://www.ons.gov.uk/peoplepopulationandcommunity/householdcharacteristics/homeinternetandsocialmediausage/articles/exploringtheuksdigitaldivide/2019-03-04">ONS</a>), finding ways to tackle digital exclusion is needed in order to help the next generation reach their full potential. This was the backdrop for the launch of The Edit, a digital storytelling challenge for schools, in partnerships with Sky and Adobe. With a mission to improve the digital and media literacy skills of young people across the UK &amp; Ireland, The Edit encourages students to have a voice and express their views on some of the most pressing issues that will affect their futures, whilst embedding the abilities they will need in the workplace of the tomorrow.</p>
+<p>Launched in 2019, the programme’s first year challenged students to create a short video news report raising awareness and action on climate change, reaching over 693 schools across the UK and Ireland, with participants gaining a wealth of new digital skills along the way. The winning students from Bolton and Livingston now have the empowering experience of seeing their entries aired on Sky News.</p>
+<p>Ben Eckersley, Associate Assistant Principal at Outwood Academy, Shafton, spoke of the impact The Edit is having on his students, <em>“Digital literacy is one of the most important things on the curriculum at the minute. These students will go out into the world of work in a few years and will be using these skills. The Edit creates a huge benefit because normally they see other students around the country having these opportunities, but it’s them this time and they absolutely love that.”</em></p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1f9d1dd92767106f4bb357e93b2eaac6cc4ea8661.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1f9d1dd92767106f4bb357e93b2eaac6cc4ea8661.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></p>
+<p>The Edit is now returning for a second year this autumn and this time, the team at Sky have joined forces with <a href="https://www.kickitout.org/">Kick it Out</a>, English Football’s quality and equality organisation. Students aged 8-18 will be challenged to produce and edit a short news report focused on an individual they feel has made the world a more equal place. Whether that’s Malala Yousafzai, Marcus Rashford or someone from their own community, students are invited to highlight how their hero has inspired them to #TakeAStand against discrimination.</p>
+<p>Students will have access to Sky content to produce their submissions, with selected entries broadcast on Sky. The winning primary school will also receive 30 shared <a href="https://www.adobe.com/uk/education/schools.html">Adobe Creative Cloud licenses</a> and the winning secondary school awarded 500 named user licences.</p>
+<p>Kayla, a student at Outwood Academy, said during the second year launch for The Edit: “<em>I liked when we were actually making the video, it was interesting to learn how to do it.”</em>, highlighting the opportunities the programme will deliver to inspire the younger generation.</p>
+<p>Tony Burnett, Kick It Out CEO, believes “<em>access to experience within the media industry should be accessible to all, despite their background, and The Edit is helping to give young people that much needed opportunity</em>.”</p>
+<p>Through the Edit we’re proud to support and #Takeastand on fighting all discrimination, as well as helping the next generation develop the skills they need for the future workplace - the <a href="https://www.theguardian.com/business/2021/mar/21/uk-digital-skills-shortage-risks-covid-recovery-as-young-people-shun-it-courses">Learning and Work Institute</a> recently found that less than half of British employers believe students are leaving full-time education with the advanced digital skills they need.</p>
+<p>Closing the digital divide involves ensuring all young people, regardless of their background or circumstance, are able to share their story. By doing so, the next generation are better equipped to be gamechangers in the workplace and beyond.</p>
+<p>Teachers can <a href="https://nationalschoolspartnership.com/initiatives/the-edit/">register ahead of The Edit year two launch here</a>, which will also give access to free lesson resources for entering the competition that can be easily tailored to students’ needs.</p>
+<div class="block-embed"><div><div><a href="https://youtu.be/e1MOaS4llzs">https://youtu.be/e1MOaS4llzs</a></div></div></div>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2021/07/12/strategies-for-teaching-diverse-learners.html">https://blog.adobe.com/en/publish/2021/07/12/strategies-for-teaching-diverse-learners.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/06/07/back-to-school-2021-how-digital-technologies-can-ease-the-return-to-in-person-education.html">https://blog.adobe.com/en/publish/2021/06/07/back-to-school-2021-how-digital-technologies-can-ease-the-return-to-in-person-education.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/06/28/how-paperless-solutions-make-it-easier-for-students-to-return-to-the-classroom.html">https://blog.adobe.com/en/publish/2021/06/28/how-paperless-solutions-make-it-easier-for-students-to-return-to-the-classroom.html</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Creativity, News, Education, UK,</p>
+<p>Products: Creative Cloud,</p>
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/17/we-stand-with-dreamers.html</id>
+    <title>We stand with Dreamers</title>
+    <updated>2021-07-17T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-westandwithdreamers embed-internal-17">
+<div>
+<h1 id="we-stand-with-dreamers">We stand with Dreamers</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_13f5f71b14fb7083fd21aee6b7f99d85eecc5c633.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_13f5f71b14fb7083fd21aee6b7f99d85eecc5c633.png?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="eager"></picture>
+</div>
+<div>
+<p>By Dana Rao</p>
+<p>Posted on 07-17-2021</p>
+</div>
+<div>
+<p><em>We are disappointed by the district court ruling on the DACA program. Welcoming people from all countries, religions and cultures is a cornerstone of American values and critical for our country’s ability to innovate and compete globally. While we remain hopeful the appeals process will find that DACA was properly authorized under the law, no one can live their lives with this persistent uncertainty. Congress must act now.</em></p>
+<p>Read more about Adobe’s support for DACA <a href="https://blog.adobe.com/en/publish/2020/06/18/celebrating-the-u-s-supreme-courts-decision-protecting-dreamers.html#gs.6513do">here</a>.</p>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2020/06/18/celebrating-the-u-s-supreme-courts-decision-protecting-dreamers.html">https://blog.adobe.com/en/publish/2020/06/18/celebrating-the-u-s-supreme-courts-decision-protecting-dreamers.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2020/06/23/u-s-executive-order-on-immigration-2020.html">https://blog.adobe.com/en/publish/2020/06/23/u-s-executive-order-on-immigration-2020.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2017/12/16/meet-daca-recipient-painting-show-no-human-illegal.html#gs.651lvi">https://blog.adobe.com/en/publish/2017/12/16/meet-daca-recipient-painting-show-no-human-illegal.html#gs.651lvi</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: News, Responsibility, Leadership, Diversity &amp; Inclusion, Public Policy, Brand,</p>
+<p>Products:</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/16/henkel-x-adobe-strategic-partnership-for-digital-innovation-and-growth.html</id>
+    <title>Henkel x Adobe: Strategic partnership for digital innovation and growth</title>
+    <updated>2021-07-16T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-henkelxadobestrategicpartnershipfordigitalinnovationandgrowth embed-internal-16">
+<div>
+<h1 id="henkel-x-adobe-strategic-partnership-for-digital-innovation-and-growth">Henkel x Adobe: Strategic partnership for digital innovation and growth</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_10fcb0c791b7fdb0ea102362a657d37e994bbb2c0.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_10fcb0c791b7fdb0ea102362a657d37e994bbb2c0.png?width=2000&amp;format=webply&amp;optimize=medium" alt="adobe henkel logo" loading="eager"></picture>
+</div>
+<div>
+<p>by Adobe Communications Team</p>
+<p>posted on 07-16-2021</p>
+</div>
+<div>
+<p>Digitalisation allows companies to engage with their customers in a variety of ways. This is both an opportunity and a challenge; while customers often automatically reach for their preferred cleaning products or cosmetics in a shop on the high street, the competition online is much higher – and rival brands are always just a few clicks away. In addition to high-quality products, the customer experience plays such an important role in brand loyalty.</p>
+<p>Personalised customer communications, relevant content at the right time on the right channel, and seamless shopping experiences are all something consumers expect as standard today. This is no longer only true in B2C; B2B buyers also expect comparable experiences in a business context.</p>
+<p>This is why Adobe and Henkel have formed a strategic partnership to accelerate digital innovation across Henkel’s existing and future brands to ensure business growth.</p>
+<p>Commenting on the partnership, Carsten Knobel, chief executive officer of Henkel said: “Adobe is globally recognised for its leading expertise in enabling partners to make a step change in their digital marketing, consumer and customer insights and e-commerce capabilities. With the development of our data-driven digital business and e-commerce platform, our businesses will be able to launch products and services faster, in a more targeted, personalised and efficient manner to our consumers and customer.”</p>
+<p>Adobe’s president and chief executive officer, Shantanu Narayen, also commented on the partnership and said: “The digital economy runs on customer connections and delivering compelling digital experiences across every channel is now a business imperative. We are proud to partner with Henkel on their mission to become a digital business. Adobe Experience Cloud will power a comprehensive digital platform for Henkel, providing a unified customer profile and delivering real-time, personalized engagements that result in customer loyalty and business growth.”</p>
+<h3 id="henkel-relies-on-adobes-technology-and-expertise">Henkel relies on Adobe’s technology and expertise</h3>
+<p>At the heart of the partnership is Henkel’s digital platform RAQN, which is based on Adobe Experience Cloud. With RAQN, the company aims to expand its e-commerce activities while addressing individual consumer and customer preferences, accelerating time-to-market and improving performance marketing based on data analytics and insights. This allows the brand to address the individual needs of its customers with tailored communication and product offerings and provide them with a seamless customer journey.</p>
+<p>“We observe a fundamental consumer and customer gravitation shift towards on-demand and hyper-personalised digital commerce. Through the partnership with Adobe, we will gain leading-edge digital experience capabilities, as well as access to Adobe’s innovation power and ecosystem to boost our digital business,” said Michael Nilles, Chief Digital and Information Officer at Henkel. “Henkel will leverage Adobe’s Experience Platform for a wide range of D2C, B2C and B2B business models to provide a superior and personalized experience across all online and offline channels for our consumers and customers.”</p>
+<p>For this, Henkel is using unified customer profiles, based on Adobe Experience Platform, as well as personalised interactions in real time to expand its business growth in the future.</p>
+<h3 id="the-future-is-digital">The future is digital</h3>
+<p>With a customised hair care line for men, ‘M:ID’, and the skincare brand ‘Kaloon Mindful Care’, two digitally-native brands have already been successfully launched on the new RAQN platform, and in record time. There were just six months between the first brainstorming sessions and the launch of these new products. Furthermore, a brand new knowledge and community platform, Henkel Laundry &amp; Home Care’s ‘Ask Team Clean’ is already available to consumers in five countries, and a global roll-out is planned.</p>
+<p>The past few months in particular have clearly highlighted the importance of outstanding digital experiences. The focus on customers and their individual needs is key for brands to stand out from the competition. With its expertise - Adobe successfully digitised its own business model several years ago – the company will now support Henkel on its way to become a digital business.</p>
+<p>Learn more about how Henkel is <a href="https://business.adobe.com/summit/2021/sessions/europe-middle-east-africa-opening-keynote-gs2.html">driving its own digital transformation</a> with its Innovation Hub “Henkel dx” (from 47:00) and how the company <a href="https://business.adobe.com/summit/community/deep-dives/henkel.html">uses and develops suitable products</a> that meet the needs of its customers.</p>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2016/11/20/three-steps-to-make-your-customer-journey-legendary.html#gs.6kvko9">https://blog.adobe.com/en/publish/2016/11/20/three-steps-to-make-your-customer-journey-legendary.html#gs.6kvko9</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2019/07/18/digital-commerce-strategy.html#gs.6kvlbn">https://blog.adobe.com/en/publish/2019/07/18/digital-commerce-strategy.html#gs.6kvlbn</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2019/03/26/3-new-ways-to-get-empowered-with-adobe-experience-cloud.html#gs.6kvl45">https://blog.adobe.com/en/publish/2019/03/26/3-new-ways-to-get-empowered-with-adobe-experience-cloud.html#gs.6kvl45</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Digital Transformation, Retail, Experience Cloud, UK,</p>
+<p>Products: Experience Platform,</p>
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/15/global-emoji-trend-report-2021.html</id>
+    <title>World Emoji Day 2021: How emoji can help create a more empathetic world, for all of us 💞</title>
+    <updated>2021-07-15T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-globalemojitrendreport2021 embed-internal-15">
+<div>
+<h1 id="world-emoji-day-2021-how-emoji-can-help-create-a-more-empathetic-world-for-all-of-us-">World Emoji Day 2021: How emoji can help create a more empathetic world, for all of us 💞</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_161154d78aff49385961f9b33cb651bc3988b9a72.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_161154d78aff49385961f9b33cb651bc3988b9a72.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="eager"></picture>
+</div>
+<div>
+<p>By Paul D. Hunt</p>
+<p>Posted on 07-15-2021</p>
+</div>
+<div>
+<p>In celebration of World Emoji Day, I am excited to share the results of Adobe’s 2021 Global Emoji Trend Report, which surveyed 7,000 people in the U.S., UK, Germany, France, Japan, Australia, and South Korea. I was surprised and delighted by the discoveries made in the survey, most notably how enthusiastic respondents were for emoji as a means to express themselves. It also answered a key question regarding the major role emoji now plays in digital communication with the strong majority stating that emoji compels them to feel more empathy towards others, an encouraging data point.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1feeae5974b7903c75ff9eb49cd81d454b36969e3.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1feeae5974b7903c75ff9eb49cd81d454b36969e3.png?width=2000&amp;format=webply&amp;optimize=medium" alt="88 percent of respondents in the 2021 Global Emoji Trend Report said that they are more likely to feel empathetic." loading="lazy"></picture></p>
+<p>I have long suspected as much— as much of my work is as a type designer and <a href="https://mashable.com/article/gender-inclusive-emoji-designer/">advocate for more inclusive emoji</a>: that these cute, colorful pictograms are also full of potential relationship building power.</p>
+<p>It is my personal belief that empathy is the most important aspect of communication. We may speak the same language as someone else, but if we are not actively trying to empathize with one another, it becomes difficult to fully understand each other’s meaning.</p>
+<p>Language can be very abstract, and this is especially the case when much of our communication is done in the digital realm — without seeing someone’s facial expressions or gestures or hearing their tone of voice. I believe we respond more emotionally to imagery, and so, emoji can help approximate tone of voice, gestures and emotional reactions better with imagery than with words alone. This is the potential strength of emoji: to help us connect more deeply to the feeling behind our messages sent by digital text.</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/products/creative-cloud/fonts.html">https://blog.adobe.com/en/promotions/products/creative-cloud/fonts.html</a></div></div></div>
+<h3 id="a-little-levity-and-cuteness-go-a-long-way">A little levity and cuteness go a long way</h3>
+<p>Emoji sometimes get criticized for being overly saccharine, but this sweetness is key when it comes to diffusing some of the heaviness of online communication. All of us have stories to tell where we accidentally came across as insincere, or even rude, in digital communications. The antidote to being perceived as a jerk, when that is likely not our intention, is to add a bit of levity and heart by integrating imagery into our messaging, to recenter the conversational tone to a place where we can show and receive more empathy. Many of the emoji are focused on positive emotions, so it’s easy to insert them into our conversations and lighten the mood.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1f54f62f091c9c4bb1c3fd354565cfbac4590163d.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1f54f62f091c9c4bb1c3fd354565cfbac4590163d.png?width=2000&amp;format=webply&amp;optimize=medium" alt=" 55 percent of respondents in the 2021 Global Emoji Trend Report said that they are more comfortable expressing emotions through emoji than phone conversations." loading="lazy"></picture></p>
+<p>It’s not surprising that over half of those surveyed feel more comfortable using emoji than talking on the phone or in-person. Emoji gives us the chance to choose an appropriate image to convey how we’re feeling and be relatable to others in the conversation. Emojis can stir up empathy even if the subject matter takes a heavy turn.</p>
+<p>This applies to less intense situations too. Dating, for example, can be tricky — especially when it’s online or via digital apps, as it often is now. It is far too easy for even the most charming amongst us to come across as weird or awkward when we’re conversing digitally. When having conversations with people in “real life,” we don’t always have to respond to everything verbally.  Sometimes we simply give someone a look or make a funny face, and that’s enough to make our point.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_18cbf36addd4ff1338fe52aeb0b60bfa7ccdb5f27.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_18cbf36addd4ff1338fe52aeb0b60bfa7ccdb5f27.png?width=2000&amp;format=webply&amp;optimize=medium" alt="According to respondents ofthe 2021 Global Emoji Trend Report the top three favored emoji in a dating scenario are 😘, 🥰, and 😍 while the 3 least favored are 🍆, 🍑, and 🤪." loading="lazy"></picture></p>
+<p>But over text, it can be much harder to know how to respond when somebody asks a direct question and you can’t find the words to say, or if you want to come across as coy, clever or cheeky. Simply responding with emoji imagery can make it much easier to express ourselves, and impart personality into the conversation.</p>
+<h3 id="communicating-across-cultures-and-languages-">Communicating across cultures and languages 💁🏾</h3>
+<p>Adobe’s global emoji study found, overwhelmingly, that emoji even helps people overcome language barriers and form connections that would otherwise be difficult to do.</p>
+<p>As a queer person, I, and many people I know, have initiated many of our meaningful relationships online, and in the social media sphere. I have made acquaintances with folks whose languages I can barely read, speak or write. I’ve chatted with people in Mandarin and Spanish, for example, and in addition to my rudimentary conversational skills, thoughtful use of emoji has often helped keep these connections intact.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_14672e20c845015cb366c966701dfc85aea31160f.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_14672e20c845015cb366c966701dfc85aea31160f.png?width=2000&amp;format=webply&amp;optimize=medium" alt="89 percent of respondents in the 2021 Global Emoji Trend Report agree that emoji make it easier for them to communicate across language barriers." loading="lazy"></picture></p>
+<p>There’s an English idiom: “a picture is worth a thousand words.” The jury’s still out on whether an emoji is worth a full 1,000 but it certainly can help in fostering global relationships.</p>
+<h3 id="an-age-of-empathy-right-on-time-🥰">An age of empathy, right on time 🥰</h3>
+<p>Recent social, racial and equality issues brought to the forefront of our daily lives have made us more aware of and empathetic to people from all walks of life, and have us trying harder than ever to understand and support one another. Anything that sparks empathy and understanding offers us a crucial benefit. We find ourselves having conversations around race, gender and equality in order to educate ourselves and our families, and to make a difference moving forward. These can be heavy topics, but even within these conversations there is room to use emoji thoughtfully. I’ve tried to do this throughout my career. For example, I successfully advocated for gender-inclusive emoji, which sparked a conversation about gender in the process.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1b9fd08e00283678d4a6da33d1da3fdaea9c5f4d2.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1b9fd08e00283678d4a6da33d1da3fdaea9c5f4d2.png?width=2000&amp;format=webply&amp;optimize=medium" alt="70 percent of respondents in the 2021 Global Emoji Trend Report agree that inclusive emoji can help spark positive conversations about important cultural and societal issues." loading="lazy"></picture></p>
+<p>My own personal philosophy about emoji is that it is a reminder that we live in a world of real things and real people — even if we are only approximating them using cartoon pictures of objects that we love, and that we use to serve as the words we can’t quite vocalize or write. Utilizing imagery often helps us connect with concepts and ideas more deeply than we would by words alone.</p>
+<p>Whether they are villainized as the despoilers of language or beloved as a fun, new way to express ourselves, emoji are most importantly another tool available to help us share our personal narratives. One of the greatest things about stories is that everyone has one. As for myself, I’m of the opinion that the best stories are illustrated with pictures 🖼, and that emotionally engaging narratives have the ability to profoundly shape the world around us for the better.</p>
+<div class="infographic"><div><div><picture><source media="(max-width: 400px)" srcset="./media_139f2c1fb0417332cb347056e90933497f19cfe8a.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_139f2c1fb0417332cb347056e90933497f19cfe8a.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></div></div></div>
+<div class="caption"><div><div><em>Fonts used in the graphics above: Adobe Clean and <a href="https://fonts.adobe.com/fonts/roc-grotesk">Roc Grotesk</a>. Check out <a href="https://fonts.adobe.com/">Adobe Fonts</a> to discover thousands of fonts included in your Creative Cloud subscription.</em></div></div></div>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2021/05/04/choose-fonts-faster-with-new-recommendations-feature.html">https://blog.adobe.com/en/publish/2021/05/04/choose-fonts-faster-with-new-recommendations-feature.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/04/08/source-han-sans-goes-variable.html">https://blog.adobe.com/en/publish/2021/04/08/source-han-sans-goes-variable.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/04/14/a-new-crop-of-fonts-with-extensive-language-support-in-creative-cloud.html">https://blog.adobe.com/en/publish/2021/04/14/a-new-crop-of-fonts-with-extensive-language-support-in-creative-cloud.html</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Creativity, Insights &amp; Inspiration, Design, Media &amp; Entertainment, Creative Cloud, UK,</p>
+<p>Products: Creative Cloud,</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/15/nurturing-digital-literacy-skills-in-higher-education-with-cutting-edge-solutions-adobe-creative-campus-collaboration-recap.html</id>
+    <title>Nurturing digital literacy skills in higher education with cutting-edge solutions: An Adobe Creative Campus Collaboration recap</title>
+    <updated>2021-07-15T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-nurturingdigitalliteracyskillsinhighereducationwithcuttingedgesolutionsadobecreativecampuscollaborationrecap embed-internal-15">
+<div>
+<h1 id="nurturing-digital-literacy-skills-in-higher-education-with-cutting-edge-solutions-an-adobe-creative-campus-collaboration-recap">Nurturing digital literacy skills in higher education with cutting-edge solutions: An Adobe Creative Campus Collaboration recap</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_1cb68ba2a8c6b706828f21af934bf81a8e6b2265d.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1cb68ba2a8c6b706828f21af934bf81a8e6b2265d.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Graphic reading &quot;Adobe Creative Campus." loading="eager"></picture>
+</div>
+<div>
+<p>By Sebastian Distefano</p>
+<p>Posted on 07-15-2021</p>
+</div>
+<div>
+<p>To conclude the current academic year and look forward to the next, Adobe hosted its quarterly Creative Campus Collaboration event, which featured speakers and panelists from across the globe who explored the inspiring ways that their institutions foster digital literacy and creative skills among faculty, staff, and students. Todd Taylor, Adobe pedagogical evangelist and Eliason distinguished professor of English at the University of North Carolina Chapel Hill, hosted the event, which revealed how colleges are:</p>
+<ul>
+<li>Creating student learning communities to enhance collaboration and prepare them for high-demand jobs</li>
+<li>Offering new training initiatives for faculty and staff to learn the latest digital tools to integrate into curricula and operational workflows</li>
+<li>Delivering more enriching learning experiences by fostering digital literacy skills among students to help them achieve milestones in their academic careers</li>
+</ul>
+<h3 id="digital-learning-for-students-and-community-at-large">Digital Learning for students and community at-large</h3>
+<p>University of Utah faculty members kicked off the Creative Campus Collaboration event with a discussion on how they spearheaded collaborative physical spaces and custom training programs to drive digital learning among students.</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/big-rock-assets/digital-literacy-cc.html">https://blog.adobe.com/en/promotions/big-rock-assets/digital-literacy-cc.html</a></div></div></div>
+<p>Cory Stokes, associate dean of Digital Learning Online &amp; Continuing Education, emphasized the importance of group collaboration, highlighting how the university has created physical spaces like the Adobe Creative Commons space in the new <a href="https://blog.adobe.com/en/publish/2020/03/05/doubling-down-on-digital-literacy-in-utah-with-creative-tools.html#gs.4636nw">Kahlert Village</a> live-and-learn facilities. Stokes emphasized the importance of spaces that facilitate in-person teamwork, saying “creativity needs a community. It needs to talk.”</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1c000aed8827c5a9d8933474f214b2c825c926dc7.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1c000aed8827c5a9d8933474f214b2c825c926dc7.png?width=2000&amp;format=webply&amp;optimize=medium" alt="Digital watercolor artwork depicting speakers Holly Johnson, Cory Stokes and Deborah Keyek-Franssen and their topics of discussion. Artwork by Karina Branson." loading="lazy"></picture></p>
+<p><em>Artwork by Karina Branson.</em></p>
+<p>Holly Johnson, associate director of Learning Experience Innovation &amp; Outreach, showcased how the institution’s new Adobe Creative Communicator Course, which was created in partnership with <a href="https://inutah.org/learn-work/">Learn &amp; Work in Utah</a>, gave all state residents the opportunity to learn digital storytelling and pursue personal career goals at no cost.</p>
+<p>The new offering from the university enrolled 120 participants, including retired teachers, software developers, students taking gap years, and recent immigrants. Johnson underscored how the course taught participants to apply their digital storytelling skills in their current and future careers, and created a close-knit community during the pandemic. For example, one student, who recently relocated to the United States from Greece, successfully leveraged her video editing skills to secure a job teaching Greek, Ancient Greek, and Latin after completing the program.</p>
+<h3 id="core-literacies-the-wonder-bread-of-higher-education">Core Literacies: The “Wonder Bread” of higher education</h3>
+<p>Dr. Chris Minnix, associate professor and director of the Signature Core Curriculum at the University of Alabama at Birmingham (UAB), led a session on the importance of teaching digital literacy skills to amplify students’ understanding of the core curricula. He challenged the idea that courses on writing, communication and quantitative reasoning are antiquated and can’t nurture high-demand skills — on the contrary, they’re pivotal to every student’s academic journey.</p>
+<p>Minnix indicated that all too often, core curricula are treated as the “Wonder Bread” of higher education. The courses are ubiquitous and requisite but are seen mainly as a service device for the “meat,” or the substance, that students achieve later in college through advanced courses in their academic discipline. To change this perception, UAB illustrated the importance of core curricula to both faculty and students, proving that these courses can <em>also</em> be interesting and engaging.</p>
+<p>Minnix explained how the university integrated core curricula with fields of study like STEM, global and ethical perspectives, and civic engagement. UAB encouraged faculty to incorporate digital tools into the core curricula, enabling students to hone their storytelling skills and more deeply immerse themselves in these core classes.</p>
+<p>“Birmingham is a global city that has impacted flows of information and ideas — it’s also a city that sends a lot of amazing ideas and people out into the world,” Minnix said. “[When creating the core curricula], we’re thinking of how we get students to recognize this rich experience and this rich civic context, from the very beginning [of their academic journey].”</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_14a3358588da25377e9dd5872eafc1f9dcdab21bc.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_14a3358588da25377e9dd5872eafc1f9dcdab21bc.png?width=2000&amp;format=webply&amp;optimize=medium" alt="Digital watercolor artwork depicting speakers Dr. Curt Carver, Dr. Chris Minnix and Dr. Allison Chapman and their topics of discussion. Artwork by Karina Branson." loading="lazy"></picture></p>
+<p><em>Artwork by Karina Branson.</em></p>
+<p>To support faculty with varying levels of familiarity and proficiency with digital tools, UAB created the Creative Cloud Fellows program, which offered customized trainings. Dr. Allison Chapman, professor and English Department Chair, took the training program a step further for her department by identifying a cohort of Creative Cloud Fellows, comprised of those who attended Adobe’s Faculty Development Institute, and could share takeaways as well as train their peers. Faculty then integrated these digital tools into their first-year English courses to promote global learning, which is a process of addressing complex issues that transcend national borders. The resulting work was displayed at the <a href="https://www.uab.edu/service-research/expo">UAB Expo</a> alongside projects completed by senior students that demonstrated how high-quality ideas can be created and shared digitally at all levels of a student’s academic journey.</p>
+<h3 id="creative-spaces-moving-from-student-engagement-to-student-empowerment">Creative Spaces: Moving from student engagement to student empowerment</h3>
+<p>Seneca College, a large urban polytechnical institution, is the first Canadian institution to become an Adobe Creative Campus. Seneca faculty and academic leaders explained how digital tools, like Adobe Creative Cloud, cultivated not only enriched engagement, but, more importantly, student agency and empowerment.</p>
+<p>Laurel Schollen, former vice president of Academic, led the effort to make Seneca an Adobe Creative Campus after attending Adobe’s annual EduMAX conference in 2016. A presentation from Dr. Rhonnda Robinson Thomas, Calhoun Lemon professor of Literature at Clemson University, opened her eyes to the accessibility of Adobe tools, and their applications outside of traditional design and art disciplines.</p>
+<p>“To me, this was the signal that creating powerful stories of learning journeys, scholarly work and project work through the use of Adobe Creative Cloud was achievable, regardless of credential level or discipline,” she said.</p>
+<p>Other campus leaders quickly saw the benefit as well. Adobe tools have since been implemented throughout the institution and are helping to cultivate student agency and empowerment.</p>
+<p>“We felt that enabling our students in business, science, health and other faculties will provide them with equal opportunity to learn these tools and prepare them better for their career aspirations,” said Radha Krishnan, chief information officer at Seneca College. “It also aligned with our vision of our digital learning strategy.”</p>
+<p>Amy Lin, director of the Teaching &amp; Learning Centre at Seneca College, highlighted the institution’s efforts to enrich faculty and student experiences as well as enhance the quality of student work by providing greater access to digital tools and training opportunities.</p>
+<p>The Teaching &amp; Learning Centre offered a series of workshops that varied by skill level and prompted faculty to use one of the three tools: <a href="https://spark.adobe.com/">Adobe Spark</a>, <a href="https://www.adobe.com/products/photoshop.html">Photoshop</a>, and <a href="https://portfolio.adobe.com">Portfolio</a>. Faculty were challenged to identify ways to use Adobe Creative Cloud tools in their classroom and require students to complete a project or assignment using them, encouraging students to leverage the tools to create expressive work and use storytelling to engage with the course material.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_133c56aaf7c8361f98e0af9089ff0e67ced725464.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_133c56aaf7c8361f98e0af9089ff0e67ced725464.png?width=2000&amp;format=webply&amp;optimize=medium" alt="Digital watercolor artwork depicting speakers Laurel Schollen, Radha Krishnan, Amy Lin and Jennifer Peters and their topics of discussion. Artwork by Karina Branson. " loading="lazy"></picture></p>
+<p><em>Artwork by Karina Branson.</em></p>
+<p>Seneca also provided best-in-class tools for staff and students beyond the classroom to ensure that all members of the college community had enriching experiences. For example, their adoption of Adobe Sign helped automate 40,000 <a href="https://acrobat.adobe.com/us/en/documentcloud/industries/education.html">digital signatures</a> for back-office documents and transcripts, allowing staff to focus on more engaging and meaningful work.</p>
+<h3 id="student-spotlight-using-creative-cloud-to-establish-a-personal-and-academic-brand">Student Spotlight: Using Creative Cloud to establish a personal and academic brand</h3>
+<p>Hillary Andales, a rising junior at Massachusetts Institute of Technology (MIT), walked participants through how she used Adobe Creative Cloud to evolve her personal brand as an “aspiring astrophysicist” who is also an accomplished creative. Andales <a href="https://blog.adobe.com/en/publish/2021/04/21/why-creative-skills-are-critical-for-the-next-generation-of-scientists-and-engineers.html">applied her digital literacy skills</a> when entering an international science competition, using <a href="https://www.adobe.com/products/premiere.html">Premiere Pro</a> and <a href="https://www.adobe.com/products/aftereffects.html">After Effects</a> to create a video explaining the concept of time relativity. She described the extensive creation process that consisted of analyzing existing video models, researching the scientific theory, as well as script-writing to engage and educate both viewers and the judging panel. In honing her storytelling efforts, she ultimately earned the top prize and funded her college education.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_14321d762a2e1dab50ab1524c5b7c22e121daa3fe.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_14321d762a2e1dab50ab1524c5b7c22e121daa3fe.png?width=2000&amp;format=webply&amp;optimize=medium" alt="Digital watercolor artwork depicting speaker Hillary Diane Andales and her topics of discussion. Artwork by Karina Branson." loading="lazy"></picture></p>
+<p><em>Artwork by Karina Branson.</em></p>
+<p>“Because I had the tools, because I had the resources, I became empowered — not just to make art — but also to fill in bigger and bigger problems that were relevant to me and to the people in my community,” Andales said. “As educators, I feel that we need to empower future magicians by giving the students the tools, the attitude, the mindset, the environment and the training to take the status quo what it is right now and transform it into something better.”</p>
+<p>She continues to refine her personal and academic brand while at MIT through “day in the life” vlogs on YouTube and digital class projects.</p>
+<h3 id="using-student-made-assets-to-improve-digital-literacy-training-for-faculty">Using student-made assets to improve Digital Literacy Training for faculty</h3>
+<p>In closing the event, Todd Taylor moderated a panel of academic leaders who shared their unique strategies for enhancing faculty development in a post-pandemic world. Dr. Wanda White, director for the Center for Innovative and Transformative Instruction at Winston Salem State University, provided an example of how student-made assets inspired faculty to use these tools for course assignments.</p>
+<p>“When we collaborated with Student Engagement and [faculty] started seeing football games being advertised through a Spark page or Premiere video, that’s when they started saying ‘oh, I can use this in my English class for a presentation,’” White said.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_14b934c0badc5d273aad429333950ed740c89a350.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_14b934c0badc5d273aad429333950ed740c89a350.png?width=2000&amp;format=webply&amp;optimize=medium" alt="Digital watercolor artwork depicting speakers Holly Johnson, Dr. Wanda White and Kyle Bowen and their topics of discussion. Artwork by Karina Branson. " loading="lazy"></picture></p>
+<p><em>Artwork by Karina Branson.</em></p>
+<p>Kyle Bowen, executive director of Learning Experience in the Office of the CIO at Arizona State University, underscored the impact of faculty who can champion digital learning and inspire their peers to leverage digital tools in their teaching practice.</p>
+<p>“These types of learning experiences aren’t just for the people who participate in them, but they have this ripple effect as they model changes for others in their departments, in other disciplines and others who might want to implement similar types of activities in their own courses,” Bowen said.</p>
+<p>Panelists unanimously agreed that by sharing student outputs and collaborating with fellow faculty, educators are more apt to pursue their own digital learning, regardless of their level.</p>
+<p>For more information on how to integrate digital skills across disciplines and throughout curricula, please visit the <a href="https://www.adobe.com/education/digital-literacy.html">Digital Literacy</a> resources page. If you’re interested in learning how your college or university can become an <a href="https://adobecreativecampus.com/">Adobe Creative Campus</a> to drive greater academic and professional success, please contact your sales representative.</p>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2021/05/06/preparing-todays-students-for-tomorrows-workforce-adobe-creative-campus-collaboration-recap.html#gs.5tpd2m">https://blog.adobe.com/en/publish/2021/05/06/preparing-todays-students-for-tomorrows-workforce-adobe-creative-campus-collaboration-recap.html#gs.5tpd2m</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/06/22/lessons-on-active-learning-in-the-covid-19-era.html#gs.5tpchg">https://blog.adobe.com/en/publish/2021/06/22/lessons-on-active-learning-in-the-covid-19-era.html#gs.5tpchg</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/04/21/why-creative-skills-are-critical-for-the-next-generation-of-scientists-and-engineers.html#gs.5tpcz9">https://blog.adobe.com/en/publish/2021/04/21/why-creative-skills-are-critical-for-the-next-generation-of-scientists-and-engineers.html#gs.5tpcz9</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Creativity, News, Education, Digital Literacy, Creative Cloud, no-interlinks</p>
+<p>Products: Creative Cloud, After Effects, Photoshop, Premiere Pro, Spark,</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/14/moving-beyond-keywords-make-visual-search-smarter-ai-understands-creative-intent.html</id>
+    <title>Moving Beyond Keywords to Make Visual Search Smarter: How AI Understands Creative Intent</title>
+    <updated>2021-07-14T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-movingbeyondkeywordsmakevisualsearchsmarteraiunderstandscreativeintent embed-internal-14">
+<div>
+<h1 id="moving-beyond-keywords-to-make-visual-search-smarter-how-ai-understands-creative-intent">Moving Beyond Keywords to Make Visual Search Smarter: How AI Understands Creative Intent</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_105b82e064845b5eb75e706f8275b2eeb85160e5b.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_105b82e064845b5eb75e706f8275b2eeb85160e5b.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Adobe Stock visual search screenshot" loading="eager"></picture>
+</div>
+<div>
+<p>By Scott Prevost</p>
+<p>Posted on 07-14-2021</p>
+</div>
+<div>
+<p>Most visual creations start with a search—for images, colors, fonts, and inspiration—but search has always felt disconnected from the creative process. It can be tedious and time-consuming to translate brilliant, imaginative ideas into words. Search terms rarely convey the aesthetics and emotions at the heart of a creative idea – which can make image search become a mind-numbing task when it should be inspiring.</p>
+<p>That’s why we’re using our artificial intelligence (AI) and machine learning technology, <a href="https://www.adobe.com/sensei.html">Adobe Sensei</a>, to fundamentally change the nature of search and help make creative visions a reality.</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/adobe-sensei-2.html">https://blog.adobe.com/en/promotions/adobe-sensei-2.html</a></div></div></div>
+<h3 id="what-ai-powered-search-can-do-and-what-it-means-for-creativity">What AI-powered search can do, and what it means for creativity</h3>
+<p>With deep learning, we’re training our search algorithms to better understand images to recognize objects—like cars, cats, humans, or even the Eiffel Tower—as well as colors, composition, style, and mood. Then, we break it all down so people can search for any of these aspects, or combine search terms and components from multiple images.</p>
+<p>The result is a search that doesn’t just find something similar to a keyword or image—it finds something similar to the exact elements that are most meaningful to the searcher. Ultimately, search captures nuance and creative intent.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_187e6dcf20cc51a2f9d4c3f3922a46060e7b97c3b.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_187e6dcf20cc51a2f9d4c3f3922a46060e7b97c3b.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Search results in Adobe Stock showing images based on a “sunset” query that also includes a specific color palette. " loading="lazy"></picture></p>
+<div class="caption"><div><div><em>Search results in Adobe Stock showing images based on a “sunset” query that also includes a specific color palette.</em></div></div></div>
+<p>Here’s an example of how it works in <a href="https://stock.adobe.com/">Adobe Stock</a>. Imagine you’ve just done a keyword search for an image of a gazelle. You have a trove of interesting gazelle photos, but none of them is quite right. To hone in on what you need, you choose an image that’s close. Then, you can use image similarity search to find gazelle photos with similar colors, content, and composition to your original. You find the perfect lone gazelle, looking to the right, with a warm color palette.</p>
+<p>But what if gazelles aren’t the only piece of your puzzle? You might also need a German shepherd in the same pose and location, so you change your keyword, but keep the composition constraints, which quickly takes you to images of a German shepherd that look remarkably like your gazelle—your dog is front and center, looking right with warm colors.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_15538febdef77210a318a45c5aa8b945f960c3476.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_15538febdef77210a318a45c5aa8b945f960c3476.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Image search in Adobe Stock for the term “gazelle”" loading="lazy"></picture></p>
+<div class="caption"><div><div><em>Image search in Adobe Stock for the term “gazelle”</em></div></div></div>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1fc34b430de4d5dbc0be8ea0b92ed7f3618f8b925.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1fc34b430de4d5dbc0be8ea0b92ed7f3618f8b925.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="“Find similar” image search results in Adobe Stock of a gazelle looking to the right, based on a sample image’s attributes (content, color and composition)" loading="lazy"></picture></p>
+<div class="caption"><div><div><em>“Find similar” image search results in Adobe Stock of a gazelle looking to the right, based on a sample image’s attributes (content, color and composition)</em></div></div></div>
+<p><picture><source media="(max-width: 400px)" srcset="./media_16df6467341fb6cd256e4b595914124aca89df9bc.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_16df6467341fb6cd256e4b595914124aca89df9bc.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="“Find similar” image search results in Adobe Stock for a ‘German shepherd’ query based on an image of a gazelle looking to the right " loading="lazy"></picture></p>
+<div class="caption"><div><div><em>“Find similar” image search results in Adobe Stock for a ‘German shepherd’ query based on an image of a gazelle looking to the right</em></div></div></div>
+<p>As you can see, the combination of keywords with visual search for subtle aspects of an image allow the search engine to understand the nuances of your aesthetic and creative vision—far beyond what it could ever do with keywords alone.</p>
+<p>Now, imagine that you want an image with a particular kind of object. Maybe you have a photo of a tent in the woods, but you want the tent further to the left, and out of the woods. You can click the tent, an object that machine learning technology can recognize, slide it where you need it, and search images with a tent in exactly the spot and scenery you desire. Eventually, you will even be able to engage several images in your search, choosing an object from one, the colors from another, and the composition from a third.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1115c57b6e679b6ebff8c4f440654408f3fa6c23c.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1115c57b6e679b6ebff8c4f440654408f3fa6c23c.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Image search in Adobe Stock for the terms “tent” and “forest”" loading="lazy"></picture></p>
+<div class="caption"><div><div><em>Image search in Adobe Stock for the terms “tent” and “forest”</em></div></div></div>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1f440f6910111b38506709bfa8208a914826ede0e.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1f440f6910111b38506709bfa8208a914826ede0e.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="“Find similar” image search results in Adobe Stock of a tent in the forest, based on a sample image’s attributes (content, color and composition) " loading="lazy"></picture></p>
+<div class="caption"><div><div><em>“Find similar” image search results in Adobe Stock of a tent in the forest, based on a sample image’s attributes (content, color and composition)</em></div></div></div>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1b4286f17318c6a5906a7706cbfd823e6443eedef.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1b4286f17318c6a5906a7706cbfd823e6443eedef.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="“Find similar” image search results in Adobe Stock of a tent in the forest, based on a sample image’s position and size of the tent – with the tent becoming the focal point of the image" loading="lazy"></picture></p>
+<div class="caption"><div><div><em>“Find similar” image search results in Adobe Stock of a tent in the forest, based on a sample image’s position and size of the tent – with the tent becoming the focal point of the image</em></div></div></div>
+<p><picture><source media="(max-width: 400px)" srcset="./media_198cb4eea11427564fd7985d4673ae78fe8d46ccb.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_198cb4eea11427564fd7985d4673ae78fe8d46ccb.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="“Find similar” image search results in Adobe Stock of a tent in the forest, based on a sample image’s position – with the tent being displayed on the left side of the image" loading="lazy"></picture></p>
+<div class="caption"><div><div><em>“Find similar” image search results in Adobe Stock of a tent in the forest, based on a sample image’s position – with the tent being displayed on the left side of the image</em></div></div></div>
+<h3 id="looking-ahead-how-search-will-create-the-things-we-imagine">Looking ahead: How search will create the things we imagine</h3>
+<p>The journey with AI and visual search is just beginning. As the tools like Adobe Stock become even smarter, search and creation will come together in a complimentary way. Eventually, AI won’t just help us find things, it will generate what we’re actually seeking. The evolution of smarter search is like a dance—humans are creating the data from which AI learns. Smarter tools, combined with the indelible spark of human creativity, will usher in new avenues for creative expression that we haven’t previously imagined.</p>
+<p>For example, imagine you’re searching for an image of person with an umbrella on a sunny day, but all the images you find are rainy days. Search will be able to apply machine learning to blend assets and create an image that never existed before—an image that’s exactly what you had in your imagination. Think of layering the magic of Photoshop to your search query and applying that to find the image you envisioned.</p>
+<p>For creatives, visual search harnessing the power of AI means cutting out a lot of the grunt work and the frustrating, clumsy keywords. By doing this, the search becomes more deeply integrated into the creative side of the work, and people have more time free to devote to the innately human side of creativity—developing and exploring new ideas.</p>
+<p><em>Portions of this article originally appeared on <a href="https://petapixel.com/2021/03/29/making-visual-search-smarter-how-ai-understands-creative-intent/">PetaPixel</a>.</em></p>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2020/01/06/ai-moving-up-the-value-chain.html">https://blog.adobe.com/en/publish/2020/01/06/ai-moving-up-the-value-chain.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2018/01/18/machine-learning-boosts-digital-creativity.html">https://blog.adobe.com/en/publish/2018/01/18/machine-learning-boosts-digital-creativity.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2019/05/16/making-sense-of-ai-what-adobe-sensei-means-for-you.html">https://blog.adobe.com/en/publish/2019/05/16/making-sense-of-ai-what-adobe-sensei-means-for-you.html</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Artificial Intelligence, Creativity, Creative Inspiration &amp; Trends, Innovation,</p>
+<p>Products: Adobe Sensei, Creative Cloud, Stock,</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/14/adobe-launches-adobe-experience-manager-screens-cloud-service.html</id>
+    <title>Adobe launches Adobe Experience Manager Screens as a Cloud Service</title>
+    <updated>2021-07-14T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-adobelaunchesadobeexperiencemanagerscreenscloudservice embed-internal-14">
+<div>
+<h1 id="adobe-launches-adobe-experience-manager-screens-as-a-cloud-service">Adobe launches Adobe Experience Manager Screens as a Cloud Service</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_15fe5d486840ef588d8c311a0f497e1688e1ca71e.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_15fe5d486840ef588d8c311a0f497e1688e1ca71e.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Close up photo of a finger pushing a touch screen. " loading="eager"></picture>
+</div>
+<div>
+<p>By Shelby Britton</p>
+<p>Posted on 07-14-2021</p>
+</div>
+<div>
+<p>As a result of the global pandemic and the resulting lockdowns, brands have spent the past year reimagining customer engagement in physical spaces. While in-store experiences may be changing, customer-obsessed brands see this as an opportunity to improve experiences by connecting online and offline channels, providing a consistent, personalized experience from web to mobile and all the way through to digital signage in physical spaces.</p>
+<p>At Adobe, enabling brands to provide a seamless customer journey across all channels has been the guiding vision for <a href="https://business.adobe.com/products/experience-manager/screens.html">Adobe Experience Manager Screens</a>. We’re accomplishing this by expanding Adobe’s best-in-class omnichannel content management capabilities to physical spaces. This purpose-built digital signage capability within Adobe Experience Manager is now offered as a cloud native service. Always up to date, the new Adobe Experience Manager Screens as a Cloud Service allows for automatic scaling support for millions of digital signage devices and unlock new possibilities in the delivery of personalized experiences at scale.</p>
+<p>The launch of Adobe Experience Manager Screens as a Cloud Service delivers on three objectives:</p>
+<ul>
+<li><strong>Omnichannel</strong>: Seamlessly extends Adobe Experience Manager Sites and Assets on Cloud Service to digital signage use cases</li>
+<li><strong>Reliability</strong>: Microservices provide resilient, reliable, and efficient content delivery to display panels</li>
+<li><strong>Scalability</strong>: Automatically scales to massive scale digital signage networks in an ever-expanding IoT world</li>
+</ul>
+<p>By delivering on these objectives, Adobe now provides its customers the foundation for delivering any type of modern digital signage experience imaginable. As an example, a fast food-chain that previously showed the same display content to customers can now benefit from the scalability of Screens as a Cloud Service to tailor the display content to each specific customer based on their order history and interaction with the brand.</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/Events/Summit/importance-digital-signage-session.html">https://blog.adobe.com/en/promotions/Events/Summit/importance-digital-signage-session.html</a></div></div></div>
+<h3 id="designed-for-efficiency-and-productivity">Designed for efficiency and productivity</h3>
+<p>As brands begin to deploy larger and larger digital signage networks across physical spaces, they are challenged with managing the volume of devices, displays and channels, as well as dealing with the complexity of the various use cases and experiences they aspire to deliver. Screens as a Cloud Service is designed with efficiency and productivity in mind to provide IT teams, store operations and marketers the tools they need to easily manage their digital signage projects and focus on delivering fantastic experiences. Efficiency and productivity benefits include:</p>
+<ul>
+<li><strong>Bulk Device Registration</strong> makes deploying mass scale networks easy and seamless</li>
+<li>Sophisticated <strong>Search and Filter</strong> enables users to quickly find displays, devices and channels</li>
+<li><strong>Device Health Snapshot</strong> provides critical stats at-a-glance</li>
+<li><strong>Objects Details Pages</strong> are streamlined, relevant and consistent across Channels, Displays and Devices</li>
+</ul>
+<h3 id="near-real-time-communications">Near real-time communications</h3>
+<p>In the digital signage space, communication happens bidirectionally where millions of IoT devices and Smart TVs report their statuses every few minutes or even seconds to the content management system (CMS). Screens as a Cloud Service is designed to fulfill those requirements by supporting fast read and write access via the cloud native architecture, allowing for near real-time communications. This also enables dynamic content and near real-time updates and messaging that power highly personalized experiences across regions and even down to customer-selected individual locations.</p>
+<h3 id="playback-success">Playback success</h3>
+<p>With Screens as a Cloud Service, Adobe manages the backend along with the client and has access to connected sensors and hardware specifications. This makes insights actionable in near real-time with Screens as a Cloud Service and across the broader ecosystem of devices and peripherals. Managing the client means Adobe is also responsible for monitoring and mitigating playback interruptions, and Screens as a Cloud Service allows Adobe to collect device and player logs in its own system, introducing smart alerting and blank screen prevention methods depending on the root cause.</p>
+<p>For more information about Adobe Experience Manager Screens as a Cloud Service, visit <a href="https://experienceleague.adobe.com/docs/experience-manager-cloud-service/screens-as-cloud-service/home.html?lang=en">here</a>.</p>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2021/06/24/adobe-launches-xml-documentation-for-adobe-experience-manager-as-a-cloud-service.html">https://blog.adobe.com/en/publish/2021/06/24/adobe-launches-xml-documentation-for-adobe-experience-manager-as-a-cloud-service.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/06/29/adobe-announces-new-personalization-capabilities-adobe-experience-cloud-help-retailers-prepare-peak-sales-periods.html">https://blog.adobe.com/en/publish/2021/06/29/adobe-announces-new-personalization-capabilities-adobe-experience-cloud-help-retailers-prepare-peak-sales-periods.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/05/19/adobe-summit-2021-recap-look-whats-possible-with-experience-manager-now.html">https://blog.adobe.com/en/publish/2021/05/19/adobe-summit-2021-recap-look-whats-possible-with-experience-manager-now.html</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Digital Transformation, News, B2B, Media &amp; Entertainment, Travel &amp; Hospitality, Experience Cloud,</p>
+<p>Products: Experience Cloud, Experience Manager,</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/13/stock-imagery-for-autumn-2021-illustrates-season-of-change.html</id>
+    <title>Autumn 2021: A season of change for stock imagery</title>
+    <updated>2021-07-13T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-stockimageryforautumn2021illustratesseasonofchange embed-internal-13">
+<div>
+<h1 id="autumn-2021-a-season-of-change-for-stock-imagery">Autumn 2021: A season of change for stock imagery</h1>
+</div>
+<div>
+<p><picture><source media="(max-width: 400px)" srcset="./media_144711300af1123151db71c44c082fa2be2edfa2d.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_144711300af1123151db71c44c082fa2be2edfa2d.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Image of two people smiling and embracing. " loading="eager"></picture></p>
+<p><em>Image Source: Adobe Stock / <a href="https://stock.adobe.com/images/affectionate-afro-girls/420732881?prev_url=detail">Nunez Image/Stocksy</a>.</em></p>
+</div>
+<div>
+<p>By Brenda Milis<br>
+Posted on 07-13-2021</p>
+</div>
+<div>
+<p>For many, the return to life as it was before the pandemic seemed to follow the old Ernest Hemingway adage about bankruptcy: it has happened gradually, and then suddenly. After a year of fits and starts, partial re-openings, returns to staying-at-home, and vaccination rollouts of varying success around the world, suddenly everything is starting to feel normal in parts of North America. For those who can, people seem ready to return to public life with an almost uncontrollable eagerness — and that eagerness is manifesting in the visuals all around us, in person and online.</p>
+<p>Autumn is always a season for family gatherings and fresh starts. It’s when we return from the dog days of summer refreshed and ready to embrace our work, studies, and daily life with renewed focus and sense of purpose. This year, many of us will also be bringing a readiness to return to a faster pace of daily life after a year and a half of being displaced and anxious about a global pandemic. For many others, that displacement and anxiety remains, or will be slow to recede, causing us to refocus on our deepest values: the loved ones and the personal pursuits that make our lives worth living.</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/stock-autumn-tones.html">https://blog.adobe.com/en/promotions/stock-autumn-tones.html</a></div></div></div>
+<p>In advertising and the wider media landscape, brands will be continuing to highlight visuals that speak to those emotions. <a href="https://stock.adobe.com/">Stock images and video</a> that depicts the season with these timely concerns and evergreen ideas in mind will have the most commercial appeal. Adobe Stock autumnal collections are brimming with family gatherings, road trips, lavish dinners, and quiet campfire chats, perfect for a season that will be at once joyful and reflective. Learn more about Adobe’s upcoming autumn trends below.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_107d1c41f211dfc645b5bcaa123a53a9a9f5b4ff3.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_107d1c41f211dfc645b5bcaa123a53a9a9f5b4ff3.png?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></p>
+<div class="infographic"><div><div><picture><source media="(max-width: 400px)" srcset="./media_1058d181d211c49d72c48d83bf654c7bc18182408.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1058d181d211c49d72c48d83bf654c7bc18182408.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></div></div></div>
+<div class="caption"><div><div><em>Image Source: Left: Adobe Stock / <a href="https://stock.adobe.com/187553137">Eldad Carin Ltd./Stocksy</a></em> <em>Right: Adobe Stock / <a href="https://stock.adobe.com/images/forest-mushrooms-at-night/429218447?prev_url=detail">Grzegorz</a></em> <em>Below: <a href="https://color.adobe.com/Brightest%20Bouquet-color-theme-17542958">Adobes Brightest Bouquet palette</a>.</em></div></div></div>
+<h3 id="a-color-palette-as-vibrant-and-lush-as-the-world-around-us">A color palette as vibrant and lush as the world around us</h3>
+<p>The <a href="https://stock.adobe.com/premium/pUaWdgWu33ABwrPjaDX6ReBgs2eZAw8p">tones and textures of autumn</a> naturally mirror the natural world around us. Each season the eye-popping candy-colored hues of summer seem to mature into a richer and warmer palette. It is a subtle difference, but we all feel it: between the jammy reds of strawberries and cherries and luscious crimson of cranberries and maple leaves, or the gap between the yellow of lemons and hay.</p>
+<p>This year’s colors will reflect an emerging optimism and deep pleasure in tonal play. The Adobe Stock Fall Flowers color palette contrasts vivacious fuchsia purples, turmeric orange, and amethyst violets with warm, almost toasty yellows and citrine. These vibrant jewel tones seem ready-made for fabric, food, and illustrations that capture opulence. Fall Flowers color palette contrasts vivacious fuchsia purples, turmeric orange, and amethyst violets with warm, almost toasty yellows and citrine. These vibrant jewel tones seem ready-made for fabric, food, and illustrations that capture opulence.</p>
+<p>Complementing this lively sense of color is the inviting and cozy palette Down to Earth. As the weather cools and people reach for their wool sweaters and favorite clay mugs, this palette melds together complimentary rich neutrals like sand, ochre, and mocha with deep saturated crimson and teal. This is the color palette for autumn walks and hikes through forests and lakes with a warm mug of tea waiting for us at the end.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_107d1c41f211dfc645b5bcaa123a53a9a9f5b4ff3.png?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_107d1c41f211dfc645b5bcaa123a53a9a9f5b4ff3.png?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></p>
+<div class="infographic"><div><div><picture><source media="(max-width: 400px)" srcset="./media_1c5eb78030a517c3f5d40c9a8295eeaf4ad75659e.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1c5eb78030a517c3f5d40c9a8295eeaf4ad75659e.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></div></div></div>
+<div class="caption"><div><div><em>Image Source: Left: Adobe Stock / <a href="https://stock.adobe.com/302309869">Ramon Lopez/ADDICTIVE STOCK</a></em> <em>Right: Adobe Stock / <a href="https://stock.adobe.com/341300839">rawpixel.com</a></em> <em>Below: <a href="https://color.adobe.com/Down%20To%20Earth-color-theme-17542949">Adobes Down to Earth palette</a>.</em></div></div></div>
+<h3 id="back-to-school-with-a-few-changes">Back to school with a few changes</h3>
+<p>Long before Covid-19 disrupted learning models across the globe, educators were starting to mix elements of virtual, distance, and online learning with traditional models, particularly at <a href="https://www.mckinsey.com/industries/public-and-social-sector/our-insights/scaling-online-education-five-lessons-for-colleges">college campuses</a> where part-time and flexible options were needed for working students. The pandemic might have abruptly brought millions of young students home, but as they return this autumn, schools have a deeper appreciation for how to mix modes of teaching.</p>
+<p>With in-person schooling comes the <a href="https://stock.adobe.com/collections/KU7nUCMnm6i1dL5Px3j5pYGC9yeIDK7N">return of students</a> expressing themselves through back-to-school outfits and accessories. Brands that cater to students and education will need to adapt for a retail environment that’s moving <a href="https://www.census.gov/retail/mrts/www/data/pdf/ec_current.pdf?_fsi=DoYG4YCH">increasingly online</a>.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1654896d33587f694aa4221a8bd26480fb0e11d21.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1654896d33587f694aa4221a8bd26480fb0e11d21.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></p>
+<p><em>Image Source: Left: Adobe Stock / <a href="https://stock.adobe.com/398232387">Santiago</a> Right: Adobe Stock / <a href="https://stock.adobe.com/419621112">Frame Studio</a>.</em></p>
+<h3 id="exploring-the-near-outdoors">Exploring the near outdoors</h3>
+<p>By some <a href="https://www.bloomberg.com/news/articles/2021-03-17/retailers-prepare-for-wave-of-shoppers-as-covid-vaccines-rollout">estimates</a>, Americans have around $1.7 trillion in excess savings that they are eager to spend after a year of self-deprivation and staying in place (a phenomenon called, distressingly, revenge spending). Across the world people have been cooped up and saving for a time when things return to normal. In the meantime, many of us are looking for ways to save our wanderlust closer to home.</p>
+<p>With countries worldwide keeping measures to reduce international travel, consumers seem happy to continue to explore their own backyards. According to a <a href="http://theharrispoll.com/wp-content/uploads/2020/10/wave-34_tabs.pdf">Harris Poll</a> last year, “69 percent of Americans say they have an increased appreciation of the experience and awareness of their surroundings when they are outside ever since lockdowns ended.” There’s a greater appreciation for the beauty and restorative powers of nature, not only as a safe place to be but a place we need to cherish and nurture.</p>
+<p>With all this energy focusing on domestic outdoors travel, brands and creators will be eager for material to express the joy and sense of adventure we get from packing up the RV and hitting the road. All over our social media feeds we’re seeing people expose themselves to the elements — leaving their comfort zones and curated households for the rustic pleasures of sleeping in a tent, or even your car. The Adobe Stock <a href="https://stock.adobe.com/collections/dDniBVrUhZVBt1XaULksVVFouzW6TiSw">Fall Outward Bound</a> collection is full of camping, hiking, fireside cooking, and other lowkey adventures.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_184f2c764812151fbff773e16d71d701b858d8c69.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_184f2c764812151fbff773e16d71d701b858d8c69.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></p>
+<p><em>Image Source: Adobe Stock / <a href="https://stock.adobe.com/316170205">Hero Images</a>.</em></p>
+<h3 id="anchor-rituals-that-bind-us-together-in-gratitude-and-celebration">Anchor rituals that bind us together in gratitude and celebration</h3>
+<p>Family reunions, whether large or small, do more than give us a chance to catch up. They help us mark the passage of time, anchoring us to a shared past and well of memories while giving us an opportunity to bond and plan. The <a href="https://stock.adobe.com/collections/BX1SQDYSnYpx06Gsk2YTwAXil3Th3V64">Fall Reunion</a> curated collection is tailored to this post-pandemic need to engage collectively in rituals large and small, from communal meals and cooking to prayer, reflection, and religious ceremonies.</p>
+<p>The Adobe Stock <a href="https://stock.adobe.com/search?gallery_id=YpqOvKV5is9HDZKolMsnAhr9N6ZGMDQk&amp;filters%5Bcontent_type%3Aphoto%5D=1&amp;filters%5Bcontent_type%3Aillustration%5D=1&amp;filters%5Bcontent_type%3Azip_vector%5D=1&amp;filters%5Bcontent_type%3Avideo%5D=1&amp;filters%5Bcontent_type%3Atemplate%5D=1&amp;filters%5Bcontent_type%3A3d%5D=1&amp;filters%5Bcontent_type%3Aaudio%5D=0&amp;filters%5Binclude_stock_enterprise%5D=0&amp;filters%5Bis_editorial%5D=0&amp;filters%5Bcontent_type%3Aimage%5D=1&amp;order=relevance&amp;safe_search=1&amp;limit=100&amp;search_page=1&amp;search_type=pagination&amp;get_facets=0">Fall Holiday</a> curated collection celebrates the huge variety of holidays this season and the communal sense of heritage they offer us. As brands start to reach a broader global audience, there is a stronger need for imagery and content that represents autumnal holidays from around the world, such as the <a href="https://stock.adobe.com/images/traditional-chinese-mooncakes/366049481?prev_url=detail">Mooncake Festival</a>, <a href="https://stock.adobe.com/templates/illustrative-dia-de-los-muertos-social-media-post-layouts/295916754?prev_url=detail">Día De Los Muertos</a>, <a href="https://stock.adobe.com/images/chinese-mid-autumn-festival-background-with-empty-golden-plate-3d-render/371000926?prev_url=detail">Chuseok</a>, <a href="https://stock.adobe.com/video/young-couple-holding-fire-sparkle-cracker-and-celebrating-new-year-or-diwali-at-night-slomotion/272981231?prev_url=detail">Diwali</a>, and <a href="https://stock.adobe.com/images/abstract-greeting-card-with-symbols-of-jewish-holiday-rosh-hashana-new-year-vector-illustration-template-design/211407669?prev_url=detail">Rosh Hashanah</a>.</p>
+<p>For American mainstays like Halloween and Thanksgiving, expect opulence and a heightened sense of exuberance: after humble household-only dinners family will be going all out to feed anyone and everyone in their communities.</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_1828354dc7d03d2da6a528ca71b22942f5bd0b8a1.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1828354dc7d03d2da6a528ca71b22942f5bd0b8a1.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></p>
+<p><em>Image Source: Left: Adobe Stock / <a href="https://stock.adobe.com/380375087">Jill Chen/Stocksy</a></em> <em>Right: Adobe Stock / <a href="https://stock.adobe.com/273786382">View Stock</a>.</em></p>
+<h3 id="call-for-content-imagery-for-a-season-of-gratitude">Call for content: Imagery for a season of gratitude</h3>
+<p>The Adobe Stock team is always looking for more seasonally relevant photography, video clips, and illustrations, and now is the perfect time for artists to contribute autumn content.</p>
+<p>Beyond the contemporary autumnal trends like pumpkin spice lattes, apple picking, and cashmere dusters, lies a season that has, for most of human history, been one of harvesting — of receiving the payoff from seasons of hard-work, care, and diligence. A common thread across the various holidays, rituals, and gatherings is one of gratitude and sharing.</p>
+<p>After this last year, families and friends are discovering how much more they have to be thankful for. Brands are always looking for diverse, honest, and fresh content to help them connect with this season of sharing.</p>
+<p>Check out the autumn 2021 collections on Adobe Stock for more inspiration. Then, sign up for a free <a href="http://contributor.stock.adobe.com/">Adobe Stock Contributor account</a>, and upload your best new seasonal images and videos to Adobe Stock.</p>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/publish/2021/06/17/depicting-dance-and-rhythm-in-internet-age.html">https://blog.adobe.com/en/publish/2021/06/17/depicting-dance-and-rhythm-in-internet-age.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/05/04/call-for-stock-content-embracing-summers-bounty.html">https://blog.adobe.com/en/publish/2021/05/04/call-for-stock-content-embracing-summers-bounty.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/04/06/take-a-deep-breath-adobes-next-visual-trend-fills-our-lungs-with-fresh-air.html">https://blog.adobe.com/en/publish/2021/04/06/take-a-deep-breath-adobes-next-visual-trend-fills-our-lungs-with-fresh-air.html</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Creativity, Insights &amp; Inspiration, Trends &amp; Research, Creative Inspiration &amp; Trends, Illustration, Photography, Video &amp; Audio, Media &amp; Entertainment, Creative Cloud,</p>
+<p>Products: Creative Cloud, Stock,</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/13/intercontinental-exchange-modernizes-documentation-global-market.html</id>
+    <title>Intercontinental Exchange modernizes documentation for the global market</title>
+    <updated>2021-07-13T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-intercontinentalexchangemodernizesdocumentationglobalmarket embed-internal-13">
+<div>
+<h1 id="intercontinental-exchange-modernizes-documentation-for-the-global-market">Intercontinental Exchange modernizes documentation for the global market</h1>
+</div>
+<div>
+<picture><source media="(max-width: 400px)" srcset="./media_1c56ee771413107fb0e61c95066d4fcc284ff284b.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_1c56ee771413107fb0e61c95066d4fcc284ff284b.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="ICE with a man looking at a computer in the background. " loading="eager"></picture>
+</div>
+<div>
+<p>By Natalie Myshkina</p>
+<p>Posted on 07-13-2021</p>
+</div>
+<div>
+<p>Information has long been considered the lifeblood of global financial markets and exchanges. For more than two decades, Intercontinental Exchange (ICE) has transformed the way that markets are operated, providing greater transparency and efficiency to keep the wheels of the global economy spinning. ICE currently operates more than a dozen exchanges and marketplaces, including the New York Stock Exchange.</p>
+<p>Technology is critical to ICE and plays a crucial role in how it transforms its own operations. Luke Xiehuan, director of information technology at ICE, is always looking for technologies that will make operations faster and more efficient, including e-signatures and digital document workflows.</p>
+<p>“E-signatures are the way of the future for all documents,” says Xiehuan. “Customers expect the ease of e-signatures. In a global environment, e-signatures are the fastest way of reaching customers everywhere. With traditional signatures on paper, you risk people not signing because they don’t want to deal with the time and hassle.”</p>
+<p>ICE switched to <a href="https://acrobat.adobe.com/us/en/sign.html">Adobe Sign</a>, the e-signature solution within <a href="https://acrobat.adobe.com/us/en/">Adobe Document Cloud</a> from their previous e-signature vendor, and have seen significant positive changes to their business processes.</p>
+<p>“Adobe Sign met all three of our biggest requirements: competitive cost, high security, and a faster onboarding time,” says Xiehuan. “The integrations with other applications were an added bonus, making workflows even faster and easier. We have cut a significant amount of paper from our processes.”</p>
+<p><picture><source media="(max-width: 400px)" srcset="./media_175fa6df9c628d33b4ba2ae74e281ade6872639b5.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_175fa6df9c628d33b4ba2ae74e281ade6872639b5.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="" loading="lazy"></picture></p>
+<h3 id="from-contracts-to-ndas-more-secure-rapid-document-workflows">From contracts to NDAs, more secure, rapid document workflows</h3>
+<p>ICE worked closely with Adobe to make the migration to Adobe Sign as seamless as possible. During that time, Xiehuan also worked directly with several Adobe teams to ensure a successful roll-out of the solution, participating in multiple short training sessions to get teams up-to-speed. As a result, ICE migrated all systems to Adobe Sign in just three months. “Adobe checked in with us frequently during and after the migration; everything went smoothly,” says Xiehuan.</p>
+<p>ICE also actively participates on the Adobe Customer Advisory Board, participating and sharing feedback on potential enhancements on future versions of the solution. The company has since implemented Adobe Sign to support all elements of its business, from sales to operations, to human resources.</p>
+<h3 id="sales">Sales</h3>
+<p>One of the top priorities for ICE is to help sales teams generate new deals and quickly respond to client requests. Working with digital contracts allows the sales team to deliver experiences to clients that are easy to sign, convenient, and secure.</p>
+<p>The sales team uses <a href="https://acrobat.adobe.com/us/en/business/integrations/salesforce.html">Adobe Sign integrated with Salesforce</a> to manage contracts, sales activation forms, and other customer-facing sales documents. The sales teams can manage their contracts entirely within Salesforce, without needing to switch between multiple apps resulting in a seamless sales user experience, a key ingredient for keeping business running efficiently.</p>
+<p>“The streamlined Salesforce integration is a major benefit with Adobe Sign,” says Xiehuan. “It was simple to set up and keeps sales representatives focused on customers rather than needing to manage paperwork.”</p>
+<p>For regulatory reasons, ICE integrated Adobe Sign with an enterprise contract repository built on <a href="https://acrobat.adobe.com/us/en/business/integrations/microsoft-sharepoint.html">Microsoft SharePoint</a> so that executed contracts automatically sync back into the repository. “With the integration between Adobe Sign and Microsoft SharePoint, we don’t need to worry about manually copying documents over,” says Xiehuan. “We know that our contracts are there when we need them.”</p>
+<h3 id="operations">Operations</h3>
+<p>The operations department also works closely with contracts. It pulls all types of contracts — including sales and procurement — into a contract database. With Adobe Sign, managing that database has become even easier. Adobe Sign connects all completed contracts with the <a href="https://acrobat.adobe.com/us/en/business/integrations/servicenow.html">ServiceNow</a> platform, which extracts applicable information and pulls it into a searchable database.</p>
+<h3 id="legal">Legal</h3>
+<p>From contracts to non-disclosure agreements, the ICE legal team deals with a large volume of documents in need of signature and approval every day. The legal team typically sends documents directly through Adobe Sign, using the app to set up signature fields, send documents, and monitor the document status. Working with fully digital workflows minimizes the risk of documents getting changed, lost, or being seen by the wrong person, keeping legal documents even more secure than typical paper processes.</p>
+<p>“Secure signature authentication is extremely important to legal and finance fields,” says Xiehuan. “Adobe has demonstrated the highest commitment to security, giving us the confidence we need to use Adobe Sign for any type of document.”</p>
+<h3 id="human-resources">Human resources</h3>
+<p>ICE knows that its most valuable resource is its employees, and Adobe Sign helps the human resources team deliver top experiences to employees. The 100 percent digital workflows make it more convenient to reach the company’s 5,000 worldwide employees when signing documents such as consent forms and non-disclosure agreements.</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/doc-cloud-fsi.html">https://blog.adobe.com/en/promotions/doc-cloud-fsi.html</a></div></div></div>
+<p>“Adobe Sign allows us to work with people anywhere in the world within minutes,” says Xiehuan. “Whether we’re dealing with customers or employees, people appreciate the ease and speed of Adobe Sign. They don’t need to register an account or remember passwords. They just open their email and with a few clicks, documents are signed and submitted.”</p>
+<p>In the two years since starting to work with Adobe Sign, ICE has processed more than 60,000 documents. Contracts are processed in an average of just seven minutes, even when working with global customers.</p>
+<p>“We’re still looking at ways that we can expand our use of Adobe Sign, particularly by taking advantage of integrations with Microsoft Office 365 and Teams to further improve efficiencies for employees,” says Xiehuan. “Like many companies, ICE has adapted to increased reliance on hybrid and remote working models over the past year. Adobe Sign helps us keep our customers and employees connected.”</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/products/document-cloud/DOC-CLOUD-BUSINESS.html">https://blog.adobe.com/en/promotions/products/document-cloud/DOC-CLOUD-BUSINESS.html</a></div></div></div>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/2020/05/29/how-tsb-bank-accelerated-its-digital-first-strategy-during-the-covid-19-pandemic.html#gs.hj5iwt">https://blog.adobe.com/en/2020/05/29/how-tsb-bank-accelerated-its-digital-first-strategy-during-the-covid-19-pandemic.html#gs.hj5iwt</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/04/23/abbvie-sets-the-stage-for-digital-transformation-with-enterprise-e-signatures-on-a-global-scale.html#gs.zi4y5f">https://blog.adobe.com/en/publish/2021/04/23/abbvie-sets-the-stage-for-digital-transformation-with-enterprise-e-signatures-on-a-global-scale.html#gs.zi4y5f</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/04/08/how-digital-workflows-and-e-signatures-are-improving-customer-experiences-at-starhub.html">https://blog.adobe.com/en/publish/2021/04/08/how-digital-workflows-and-e-signatures-are-improving-customer-experiences-at-starhub.html</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Customer Stories, Insights &amp; Inspiration, Financial Services, Document Cloud,</p>
+<p>Products: Document Cloud, Sign,</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+  <entry>
+    <id>https://blog.adobe.com/en/publish/2021/07/13/sika-brings-innovation-and-sustainability-to-global-business-processes.html</id>
+    <title>Sika brings innovation and sustainability to global business processes</title>
+    <updated>2021-07-13T00:00:00.000Z</updated>
+    <content><![CDATA[
+      <div class="embed embed-internal embed-internal-sikabringsinnovationandsustainabilitytoglobalbusinessprocesses embed-internal-13">
+<div>
+<h1 id="sika-brings-innovation-and-sustainability-to-global-business-processes">Sika brings innovation and sustainability to global business processes</h1>
+</div>
+<div>
+<p><picture><source media="(max-width: 400px)" srcset="./media_170c79180f12bde35c2ea3625420f93db5e44af2f.jpeg?width=750&amp;format=webply&amp;optimize=medium"><img src="./media_170c79180f12bde35c2ea3625420f93db5e44af2f.jpeg?width=2000&amp;format=webply&amp;optimize=medium" alt="Sika Building Trust." loading="eager"></picture>.</p>
+</div>
+<div>
+<p>By Stephanie Krausse</p>
+<p>Posted on 07-13-2021</p>
+</div>
+<div>
+<p>Sika is known for its leading position in the development and production of systems and products for bonding, sealing, damping, reinforcing, and protection in the building sector and automotive industry. Sika solutions enable sustainable construction and transportation, with subsidiaries in 100 countries around the world, while manufacturing in over 300 factories.</p>
+<p>The IT team at Sika — including David Ferrer, project manager for Web Applications, and Peter Simon, team head of Web &amp; Digital Solutions — takes pride in how their team brings the spirit of innovation to processes across the company.</p>
+<p>“I’m passionate about changing and improving the way people work,” explains Simon. “If I can make their everyday processes more efficient, then I can give them more time to focus on what’s most important to them, whether that’s training employees, talking to vendors, or developing new chemical additives that will revolutionize the construction industry.”</p>
+<p>Working with <a href="https://acrobat.adobe.com/us/en/sign.html">Adobe Sign</a>, Sika gains a tool that teams can use to digitize any document, from service and purchase orders to NDAs and work contracts. “The demand for Adobe Sign was far beyond what we expected,” says Simon. “We’ve had 3,000 transactions in the first six months of deploying Adobe Sign, with about a 30 percent increase every month. Once people see how Adobe Sign increases their efficiency, they’re more than happy to go digital.”</p>
+<div class="promotion"><div><div><a href="https://blog.adobe.com/en/promotions/products/document-cloud/sign.html">https://blog.adobe.com/en/promotions/products/document-cloud/sign.html</a></div></div></div>
+<h3 id="flexibility-to-adapt-to-any-business-use">Flexibility to adapt to any business use</h3>
+<p>Sika has long worked with best-in-class Adobe applications, including <a href="https://www.adobe.com/creativecloud.html">Adobe Creative Cloud</a>, <a href="https://business.adobe.com/">Adobe Experience Cloud</a>, and <a href="https://acrobat.adobe.com/us/en/acrobat.html">Adobe Acrobat</a>. When Sika began looking at e-signature solutions, Adobe Sign surfaced as the best choice as it’s backed by the same trusted Adobe brand.</p>
+<p>“Adobe Sign has all of the functionality that we need, including strong integrations with Microsoft and many other solutions,” says Simon. “The ease of use was also critical for us to support adoption across 25,000 employees. It’s so intuitive that we didn’t need to spend a lot of time on training.”</p>
+<p>Within the first six months of the integration of Adobe Sign, Sika has already saved resources globally by eliminating printing, mailing, and manual labor costs associated with paper-based processes. More than 800 users currently use Adobe Sign to create seamless digital workflows for approvals, contracts, and all types of paperwork approval processes.</p>
+<h3 id="increased-visibility-and-faster-approvals-globally">Increased visibility and faster approvals, globally</h3>
+<p><strong>Portugal</strong></p>
+<p>Teams in Portugal use Adobe Sign to process many different types of customer-facing paperwork, including sales orders, warranties, and product returns. Customer service teams can quickly initiate credit for product returns through Adobe Sign. With greater visibility into where documents are — whether they’ve been viewed or signed by approvers — customer service teams can quickly and confidently reassure customers that the return is being reviewed. Credit is processed faster, leading to an even higher degree of customer focus.</p>
+<p>The sales team has been able to considerably reduce the time to process orders. Sika can now review, approve and sign sales requests in less than 24 hours. Portuguese sales representatives can spend more time on adding greater value to their customers, thanks to the automated templates and workflows created in Adobe Sign.</p>
+<p><strong>Saudi Arabia</strong></p>
+<p>In Saudi Arabia, teams take advantage of the templates and workflows to automate a wide variety of day-to-day administrative tasks, from purchase orders, price discounts, employee vacation requests and business travel reimbursements. Adobe Sign also accelerates approvals when stakeholders are traveling or are working in different cities, leading to faster decision-making processes.</p>
+<p>With the sales team using Adobe Sign, agreements can be completed in under two hours instead of taking up to four days. This gives the sales representatives the ability to complete more sales quotes for potential customers, leading to greater overall sales growth for the company.</p>
+<h3 id="expanding-adoption-with-support-from-the-top">Expanding adoption with support from the top</h3>
+<p>Interest in Adobe Sign is growing rapidly, partially due to strong support from internal advocates. Many teams at Sika have quickly realized the benefits of Adobe Sign for its strong audit trails, which records information such as who signed a document, when, and from what IP address. Corporate teams also helped to spread the word when they realized the administrative and cost-saving benefits of Adobe Sign.</p>
+<p>Corporate IT at Sika wants to make Adobe Sign available to every employee who works with documents, approvals and signatures. This team is also evaluating further the integrations of Adobe Sign with additional solutions to support seamless and automated workflows that pull data into templates and send documents for signature to the right parties.</p>
+<p>“There are many products on the market that digitize workflows and signatures for very specific purposes, but Adobe Sign has the flexibility to integrate any workflow, any solution, and any use case,” says Ferrer. “Sika staff will be able to work more efficiently by taking advantage of the easy-to-use solution and full functionalities of Adobe Sign.”</p>
+</div>
+<div>
+<h2 id="featured-posts">Featured posts:</h2>
+<ul>
+<li><a href="https://blog.adobe.com/en/2020/05/29/how-tsb-bank-accelerated-its-digital-first-strategy-during-the-covid-19-pandemic.html#gs.hj5iwt">https://blog.adobe.com/en/2020/05/29/how-tsb-bank-accelerated-its-digital-first-strategy-during-the-covid-19-pandemic.html#gs.hj5iwt</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/05/28/how-health-infrastructure-simplified-its-work-from-home-transition.html">https://blog.adobe.com/en/publish/2021/05/28/how-health-infrastructure-simplified-its-work-from-home-transition.html</a></li>
+<li><a href="https://blog.adobe.com/en/publish/2021/04/23/abbvie-sets-the-stage-for-digital-transformation-with-enterprise-e-signatures-on-a-global-scale.html#gs.zi4y5f">https://blog.adobe.com/en/publish/2021/04/23/abbvie-sets-the-stage-for-digital-transformation-with-enterprise-e-signatures-on-a-global-scale.html#gs.zi4y5f</a></li>
+</ul>
+</div>
+<div>
+<p>Topics: Customer Stories, Insights &amp; Inspiration, Document Cloud,</p>
+<p>Products: Document Cloud, Sign,</p>
+
+</div>
+</div>
+
+   ]]></content>
+  </entry>
+
+</feed>

--- a/FeedReader.Tests/FullParseTest.cs
+++ b/FeedReader.Tests/FullParseTest.cs
@@ -17,6 +17,21 @@ namespace CodeHollow.FeedReader.Tests
 
         #region Synchronous 
 
+                [TestMethod]
+        public void TestAtomParseAdobe()
+        {
+            var feed = (AtomFeed)FeedReader.ReadFromFile("Feeds/AtomAdobe.xml").SpecificFeed;
+
+            Eq("Adobe Blog", feed.Title);
+            Eq(null, feed.Icon);
+            Eq("https://blog.adobe.com/", feed.Link);
+            Eq("2021-07-19T00:00:00.000Z", feed.UpdatedDateString);
+            Eq("https://blog.adobe.com/", feed.Id);
+
+            var item = (AtomFeedItem)feed.Items.First();
+            Eq(null, item.Link); // The post href is store in the id element
+        }
+
         [TestMethod]
         public void TestAtomParseTheVerge()
         {
@@ -380,6 +395,21 @@ namespace CodeHollow.FeedReader.Tests
         #endregion Synchronous 
 
         #region Asynchronous 
+
+        [TestMethod]
+        public async Task TestAtomParseAdobe_Async()
+        {
+            var feed = (AtomFeed)(await FeedReader.ReadFromFileAsync("Feeds/AtomAdobe.xml").ConfigureAwait(false)).SpecificFeed;
+
+            Eq("Adobe Blog", feed.Title);
+            Eq(null, feed.Icon);
+            Eq("https://blog.adobe.com/", feed.Link);
+            Eq("2021-07-19T00:00:00.000Z", feed.UpdatedDateString);
+            Eq("https://blog.adobe.com/", feed.Id);
+
+            var item = (AtomFeedItem)feed.Items.First();
+            Eq(null, item.Link); // The post href is store in the id element
+        }
 
         [TestMethod]
         public async Task TestAtomParseTheVerge_Async()

--- a/FeedReader/Feeds/Atom/AtomFeedItem.cs
+++ b/FeedReader/Feeds/Atom/AtomFeedItem.cs
@@ -1,4 +1,4 @@
-﻿namespace CodeHollow.FeedReader.Feeds
+namespace CodeHollow.FeedReader.Feeds
 {
     using System;
     using System.Collections.Generic;
@@ -92,7 +92,7 @@
         public AtomFeedItem(XElement item)
             : base(item)
         {
-            this.Link = item.GetElement("link").Attribute("href")?.Value;
+            this.Link = item.GetElement("link")?.Attribute("href")?.Value;
 
             this.Author = new AtomPerson(item.GetElement("author"));
 


### PR DESCRIPTION
Entries in this feed (https://blog.adobe.com/feed.xml) are missing the 'link' elements and instead the href to the post is set in the 'id' element.

Fixed so that FeedReader does not crash if the 'link' element is missing.

Fixes #39