### PR TITLE
Enabled automatic decompression of HTTP content

### DIFF
--- a/FeedReader.Tests/FeedReaderTest.cs
+++ b/FeedReader.Tests/FeedReaderTest.cs
@@ -91,6 +91,14 @@ namespace CodeHollow.FeedReader.Tests
         #region Read Feed
 
         [TestMethod]
+        public async Task TestReadAdobeFeed()
+        {
+            var feed = await FeedReader.ReadAsync("https://theblog.adobe.com/news/feed").ConfigureAwait(false);
+            string title = feed.Title;
+            Assert.AreEqual("Adobe Blog", title);
+        }
+
+        [TestMethod]
         public async Task TestReadSimpleFeed()
         {
             var feed = await FeedReader.ReadAsync("https://arminreiter.com/feed").ConfigureAwait(false);

--- a/FeedReader/Helpers.cs
+++ b/FeedReader/Helpers.cs
@@ -1,11 +1,10 @@
 ﻿namespace CodeHollow.FeedReader
 {
-    using CodeHollow.FeedReader.Parser;
     using Feeds.MediaRSS;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -24,7 +23,12 @@
 
         // The HttpClient instance must be a static field
         // https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
-        private static readonly HttpClient _httpClient = new HttpClient();
+        private static readonly HttpClient _httpClient = new HttpClient(
+            new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            }
+        );
 
         /// <summary>
         /// Download the content from an url
@@ -141,7 +145,7 @@
                 if (!parseSuccess)
                 {
                     string newdtstring = datetime.Substring(0, datetime.LastIndexOf(" ")).Trim();
-                    
+
                     parseSuccess = DateTimeOffset.TryParse(newdtstring, dateTimeFormat, DateTimeStyles.AssumeUniversal,
                         out dt);
                 }
@@ -225,7 +229,7 @@
 
             return null;
         }
-        
+
         /// <summary>
         /// Returns a HtmlFeedLink object from a linktag (link href="" type="")
         /// only support application/rss and application/atom as type


### PR DESCRIPTION
This is needed for feeds that send content compressed, such as https://theblog.adobe.com/news/feed

Fixes #44 