### PR TITLE
Fix for & char that causes XDocument.parse to fail

### DIFF
--- a/FeedReader/Parser/FeedParser.cs
+++ b/FeedReader/Parser/FeedParser.cs
@@ -138,6 +138,7 @@
 
             feedContent = feedContent.Replace(((char)127).ToString(), string.Empty);   // replace DEL
             feedContent = feedContent.Replace(((char)65279).ToString(), string.Empty); // replaces special char, fixes issues with at least one feed
+            feedContent = feedContent.Replace("&", "&amp;"); // replaces & char with HTML encoded version.
 
             return feedContent.Trim();
         }


### PR DESCRIPTION
XDocument.Parse fails when it tries to parse `&`. It works when we replace `&` with `&amp;` which is  HTML encoded version of it.